### PR TITLE
multiple access points added

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ issues with Home Assistant gracefully and ensures that device state is always in
 
 * Log in to your OpenWRT device
 * Place presence-detector.py and settings.json somewhere persistent (I use /etc/config)
+* Make presence-detector.py executable: chmod +x presence-detector.py
 * Place the init-script from this repo's init.d directory into /etc/init.d on your device
 * Install python + deps: opkg update && opkg install python3-requests
 * Adjust settings.json to your needs (see below)
@@ -27,6 +28,7 @@ The settings file looks like this:
   "offline_after": 3,
   "poll_interval": 15,
   "full_sync_polls": 10,
+  "ap_name": "",
   "debug": false
 }
 ```
@@ -37,8 +39,10 @@ Some settings will need a bit of explaining:
   then scolling all the way down to 'Long-lived tokens' and clicking 'Create Token'
 * interfaces: This is an array of Wifi interface names to poll, prefixed with 'hostapd.' (it's the ubus service name)
 * offline_after: Set a device as not_home after is has been absent for this many poll intervals
+* poll_interval: Poll interval in seconds
 * full_sync_polls: Re-sync the device state of all devices every X poll intervals. This is to ensure device state is in sync,
   even after HA restarts, connectivity loss, or missed events.
+* ap_name: If only one access point, leave as "". If script should run on multiple access points, give a name here, e.g. "ap1". The mac address will be prefixed by this on HA.
 * debug: Enable or disable debugging (prints state information on stdout when enabled)
 
 ## Logging ##

--- a/presence-detector.py
+++ b/presence-detector.py
@@ -96,6 +96,10 @@ class PresenceDetector:
                 if process.returncode == 0:
                     clients = json.loads(process.stdout)
                     for client in clients['clients']:
+                        # Add ap prefix if ap_name defined in settings
+                        if bool(self.settings.ap_name):
+                            ap = self.settings.ap_name + '_'
+                            client = ap + client
                         if client not in self.clients_seen:
                             self.logger.log(f"Device {client} is now home")
                             if self.ha_seen(client):

--- a/presence-detector.py
+++ b/presence-detector.py
@@ -99,7 +99,6 @@ class PresenceDetector:
                         # Add ap prefix if ap_name defined in settings
                         if self.settings.ap_name:
                             client = f"{self.settings.ap_name}_{client}"
-                            client = ap + client
                         if client not in self.clients_seen:
                             self.logger.log(f"Device {client} is now home")
                             if self.ha_seen(client):

--- a/presence-detector.py
+++ b/presence-detector.py
@@ -97,7 +97,8 @@ class PresenceDetector:
                     clients = json.loads(process.stdout)
                     for client in clients['clients']:
                         # Add ap prefix if ap_name defined in settings
-                        if bool(self.settings.ap_name):
+                        if self.settings.ap_name:
+                            client = f"{self.settings.ap_name}_{client}"
                             ap = self.settings.ap_name + '_'
                             client = ap + client
                         if client not in self.clients_seen:

--- a/presence-detector.py
+++ b/presence-detector.py
@@ -99,7 +99,6 @@ class PresenceDetector:
                         # Add ap prefix if ap_name defined in settings
                         if self.settings.ap_name:
                             client = f"{self.settings.ap_name}_{client}"
-                            ap = self.settings.ap_name + '_'
                             client = ap + client
                         if client not in self.clients_seen:
                             self.logger.log(f"Device {client} is now home")

--- a/settings.json.example
+++ b/settings.json.example
@@ -5,5 +5,6 @@
   "offline_after": 3,
   "poll_interval": 15,
   "full_sync_polls": 10,
+  "ap_name": "",
   "debug": false
 }


### PR DESCRIPTION
added the possibility to use the scripts on multiple access points by adding a settings variable ap_name. The parameter is prefixed to the mac address. If left empty or variable omitted, mac address not prefixed.

There might be a more elegant way to add this feature - I am a python noob. Thank you for your useful script!