### PR TITLE
Small improvements in customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The settings file looks like this:
   "full_sync_polls": 10,
   "ap_name": "",
   "location": "home",
+  "away": "not_home",
   "debug": false
 }
 ```
@@ -55,6 +56,7 @@ Some settings will need a bit of explaining:
   even after HA restarts, connectivity loss, or missed events.
 * ap_name: If only one access point, leave as "". If script should run on multiple access points, give a name here, e.g. "ap1". The mac address will be prefixed by this on HA.
 * location: Custom location name to be assigned to spotted devices.
+* away: Custom location name to be sent when a device is no more connected.
 * debug: Enable or disable debugging (prints state information on stdout when enabled).
 
 ## Logging ##

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The settings file looks like this:
       "hostname": "Dave",
       "dev_id": "phonedave"
     }
-  }
+  },
   "offline_after": 3,
   "poll_interval": 15,
   "full_sync_polls": 10,

--- a/README.md
+++ b/README.md
@@ -25,25 +25,37 @@ The settings file looks like this:
   "hass_url": "http://hassio.local:8123",
   "hass_token" : "<Home Assistant REST API Bearer Token>",
   "interfaces": ["hostapd.wlan0", "hostapd.wlan1"],
+  "do_not_track": ["01:23:45:67:89:ab"],
+  "params": {
+    "00:00:00:00:00:00": {
+      "mac": "ff:ff:ff:ff:ff:ff",
+      "hostname": "Dave",
+      "dev_id": "phonedave"
+    }
+  }
   "offline_after": 3,
   "poll_interval": 15,
   "full_sync_polls": 10,
   "ap_name": "",
+  "zone": "my_zone",
   "debug": false
 }
 ```
 
 Some settings will need a bit of explaining:
-* hass_url: The URL to your Home Assistant device, including the port (8123 is the default Hass.io port)
+* hass_url: The URL to your Home Assistant device, including the port (8123 is the default Hass.io port).
 * hass_token: This is a Home Assistant 'Long-lived token'. You can create it in the HA web-ui by clicking on your user-name,
-  then scolling all the way down to 'Long-lived tokens' and clicking 'Create Token'
-* interfaces: This is an array of Wifi interface names to poll, prefixed with 'hostapd.' (it's the ubus service name)
-* offline_after: Set a device as not_home after is has been absent for this many poll intervals
-* poll_interval: Poll interval in seconds
+  then scolling all the way down to 'Long-lived tokens' and clicking 'Create Token'.
+* interfaces: This is an array of Wifi interface names to poll, prefixed with 'hostapd.' (it's the ubus service name).
+* do_not_track: This is an array of devices to ignore.
+* params: A dictionary containing additional parameters for specific devices. Those are sent together with MAC address and location name. Note here you could also override MAC and location name. For information on which keys you can add, see [here](https://www.home-assistant.io/integrations/device_tracker/#device_trackersee-service).
+* offline_after: Set a device as not_home after is has been absent for this many poll intervals.
+* poll_interval: Poll interval in seconds.
 * full_sync_polls: Re-sync the device state of all devices every X poll intervals. This is to ensure device state is in sync,
   even after HA restarts, connectivity loss, or missed events.
 * ap_name: If only one access point, leave as "". If script should run on multiple access points, give a name here, e.g. "ap1". The mac address will be prefixed by this on HA.
-* debug: Enable or disable debugging (prints state information on stdout when enabled)
+* zone: Custom zone name to be assigned to spotted devices.
+* debug: Enable or disable debugging (prints state information on stdout when enabled).
 
 ## Logging ##
 The program will run as a 'service' in the background and will log interesting events to syslog.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The settings file looks like this:
   "poll_interval": 15,
   "full_sync_polls": 10,
   "ap_name": "",
-  "zone": "my_zone",
+  "location": "home",
   "debug": false
 }
 ```
@@ -54,7 +54,7 @@ Some settings will need a bit of explaining:
 * full_sync_polls: Re-sync the device state of all devices every X poll intervals. This is to ensure device state is in sync,
   even after HA restarts, connectivity loss, or missed events.
 * ap_name: If only one access point, leave as "". If script should run on multiple access points, give a name here, e.g. "ap1". The mac address will be prefixed by this on HA.
-* zone: Custom zone name to be assigned to spotted devices.
+* location: Custom location name to be assigned to spotted devices.
 * debug: Enable or disable debugging (prints state information on stdout when enabled).
 
 ## Logging ##

--- a/presence-detector.py
+++ b/presence-detector.py
@@ -96,6 +96,8 @@ class PresenceDetector:
                 if process.returncode == 0:
                     clients = json.loads(process.stdout)
                     for client in clients['clients']:
+                        if client in self.settings.do_not_track:
+                            continue
                         # Add ap prefix if ap_name defined in settings
                         if self.settings.ap_name:
                             client = f"{self.settings.ap_name}_{client}"

--- a/presence-detector.py
+++ b/presence-detector.py
@@ -33,6 +33,7 @@ class Settings:
             "poll_interval": 15,
             "full_sync_polls": 10,
             "location": "home",
+            "away": "not_home",
             "debug": False
         }
         with open(config_file, 'r') as settings:
@@ -50,9 +51,10 @@ class PresenceDetector:
         self.clients_seen = {}
 
     def ha_seen(self, client, seen=True):
-        location = self.settings.location
-        if not seen:
-            location = "unknown"
+        if seen:
+            location = self.settings.location
+        else:
+            location = self.settings.away
 
         body = {"mac": client, "location_name": location}
         if client in self.settings.params:

--- a/presence-detector.py
+++ b/presence-detector.py
@@ -27,9 +27,12 @@ class Settings:
         self._settings = {
             "hass_url": "http://homeassistant.local:8123",
             "interfaces": ["hostapd.wlan0"],
+            "do_not_track": [],
+            "params": {},
             "offline_after": 3,
             "poll_interval": 15,
             "full_sync_polls": 10,
+            "zone": "home",
             "debug": False
         }
         with open(config_file, 'r') as settings:

--- a/presence-detector.py
+++ b/presence-detector.py
@@ -46,6 +46,11 @@ class PresenceDetector:
 
         body = {"mac": client, "location_name": location}
         try:
+            body.update(self.settings.params[client])
+        except:
+            pass
+
+        try:
             response = requests.post(f'{self.settings.hass_url}/api/services/device_tracker/see', json=body,
                                      headers={'Authorization': f'Bearer {self.settings.hass_token}'})
             self.logger.log(f"API Response: {response.content}", is_debug=True)

--- a/presence-detector.py
+++ b/presence-detector.py
@@ -40,9 +40,9 @@ class PresenceDetector:
         self.clients_seen = {}
 
     def ha_seen(self, client, seen=True):
-        location = "home"
+        location = self.settings.zone
         if not seen:
-            location = "not_home"
+            location = "unknown"
 
         body = {"mac": client, "location_name": location}
         try:
@@ -102,7 +102,7 @@ class PresenceDetector:
                         if self.settings.ap_name:
                             client = f"{self.settings.ap_name}_{client}"
                         if client not in self.clients_seen:
-                            self.logger.log(f"Device {client} is now home")
+                            self.logger.log(f"Device {client} is now at {self.settings.zone}")
                             if self.ha_seen(client):
                                 self.clients_seen[client] = self.settings.offline_after
                         else:

--- a/presence-detector.py
+++ b/presence-detector.py
@@ -55,10 +55,8 @@ class PresenceDetector:
             location = "unknown"
 
         body = {"mac": client, "location_name": location}
-        try:
+        if client in self.settings.params:
             body.update(self.settings.params[client])
-        except:
-            pass
 
         try:
             response = requests.post(f'{self.settings.hass_url}/api/services/device_tracker/see', json=body,

--- a/presence-detector.py
+++ b/presence-detector.py
@@ -18,7 +18,7 @@ class Logger:
             return
 
         level = syslog.LOG_DEBUG if is_debug else syslog.LOG_INFO
-        syslog.openlog(ident="presense-detector", facility=syslog.LOG_DAEMON, logoption=syslog.LOG_PID)
+        syslog.openlog(ident="presence-detector", facility=syslog.LOG_DAEMON, logoption=syslog.LOG_PID)
         syslog.syslog(level, text)
 
 

--- a/presence-detector.py
+++ b/presence-detector.py
@@ -32,7 +32,7 @@ class Settings:
             "offline_after": 3,
             "poll_interval": 15,
             "full_sync_polls": 10,
-            "zone": "home",
+            "location": "home",
             "debug": False
         }
         with open(config_file, 'r') as settings:
@@ -50,7 +50,7 @@ class PresenceDetector:
         self.clients_seen = {}
 
     def ha_seen(self, client, seen=True):
-        location = self.settings.zone
+        location = self.settings.location
         if not seen:
             location = "unknown"
 
@@ -115,7 +115,7 @@ class PresenceDetector:
                         if self.settings.ap_name:
                             client = f"{self.settings.ap_name}_{client}"
                         if client not in self.clients_seen:
-                            self.logger.log(f"Device {client} is now at {self.settings.zone}")
+                            self.logger.log(f"Device {client} is now at {self.settings.location}")
                             if self.ha_seen(client):
                                 self.clients_seen[client] = self.settings.offline_after
                         else:

--- a/settings.json.example
+++ b/settings.json.example
@@ -9,7 +9,7 @@
       "hostname": "Dave",
       "dev_id": "phonedave"
     }
-  }
+  },
   "offline_after": 3,
   "poll_interval": 15,
   "full_sync_polls": 10,

--- a/settings.json.example
+++ b/settings.json.example
@@ -7,5 +7,6 @@
   "poll_interval": 15,
   "full_sync_polls": 10,
   "ap_name": "",
+  "zone": "my_zone",
   "debug": false
 }

--- a/settings.json.example
+++ b/settings.json.example
@@ -14,6 +14,6 @@
   "poll_interval": 15,
   "full_sync_polls": 10,
   "ap_name": "",
-  "zone": "my_zone",
+  "location": "home",
   "debug": false
 }

--- a/settings.json.example
+++ b/settings.json.example
@@ -15,5 +15,6 @@
   "full_sync_polls": 10,
   "ap_name": "",
   "location": "home",
+  "away": "not_home",
   "debug": false
 }

--- a/settings.json.example
+++ b/settings.json.example
@@ -2,6 +2,7 @@
   "hass_url": "http://hassio.local:8123",
   "hass_token" : "<Home Assistant REST API Bearer Token>",
   "interfaces": ["hostapd.wlan0", "hostapd.wlan1"],
+  "do_not_track": ["01:23:45:67:89:ab"],
   "offline_after": 3,
   "poll_interval": 15,
   "full_sync_polls": 10,

--- a/settings.json.example
+++ b/settings.json.example
@@ -3,6 +3,13 @@
   "hass_token" : "<Home Assistant REST API Bearer Token>",
   "interfaces": ["hostapd.wlan0", "hostapd.wlan1"],
   "do_not_track": ["01:23:45:67:89:ab"],
+  "params": {
+    "01:23:45:67:89:ab": {
+      "mac": "ff:ff:ff:ff:ff:ff",
+      "hostname": "Dave",
+      "dev_id": "phonedave"
+    }
+  }
   "offline_after": 3,
   "poll_interval": 15,
   "full_sync_polls": 10,


### PR DESCRIPTION
- do_not_track: ignore some devices (could be WiFi sensors or a smart TV)
- zone: defines a custom name for zone to not be limited to `home` and `not_home`. Also `not_home` has been changed to `unknown` since you don't know where the device is when it leaves.
- params: defines a per-device list of parameters to customize or override sent data. See https://www.home-assistant.io/integrations/device_tracker/#device_trackersee-service