### PR TITLE
Fix polling loop bug and mark devices as away faster

### DIFF
--- a/presence-detector.py
+++ b/presence-detector.py
@@ -219,7 +219,8 @@ class UbusWatcher(Thread):
                 pass
             if "assoc" in event:
                 self._detector.set_client_home(event["assoc"]["address"])
-
+            elif "disassoc" in event and self._detector._settings.offline_after <= 1:
+                self._detector.set_client_away(event["disassoc"]["address"])
 
 def main():
     parser = argparse.ArgumentParser()

--- a/presence-detector.py
+++ b/presence-detector.py
@@ -170,15 +170,18 @@ class PresenceDetector(Thread):
 
         # The main (sync) polling loop
         while not self._killed:
+            seen_now = self._get_all_online_clients()
+            for client in seen_now:
+                self.set_client_home(client)
+
             for client in self._clients_seen.copy():
+                if client in seen_now:
+                    continue
                 self._clients_seen[client] -= 1
                 if self._clients_seen[client] > 0:
                     continue
                 # Client has not been seen x times, mark as away
                 self.set_client_away(client)
-
-            for client in self._get_all_online_clients():
-                self.set_client_home(client)
 
             time.sleep(self._settings.poll_interval)
             self.full_sync()


### PR DESCRIPTION
Hi. Thanks for this script, very useful!

I have made 2 improvements (please read the individual commit messages for full explanation):
1. fix the polling loop so if `offline_after` is set to 1 devices don't go away and come back on every poll
2. if `offline_after` is set to 1 (or less), then there's no need to wait so devices are marked as away immediately
