### PR TITLE
stop() bugfix, settings.json renaming and requests library replaced

### DIFF
--- a/presence-detector.py
+++ b/presence-detector.py
@@ -70,13 +70,15 @@ class PresenceDetector(Thread):
         self._killed = False
 
     @staticmethod
-    def _post(url: str, data: dict = None, headers: dict = None, timeout: int = None):
-        if data is None:
-            data = {}
-        if headers is None:
-            headers = {}
-        data = json.dumps(data).encode("utf-8")
-        req = request.Request(url, data=data, headers=headers)
+    def _post(url: str,
+              data: dict | None = None,
+              headers: dict | None = None,
+              timeout: int | None = None):
+        data = data or {}
+        headers = headers or {}
+        req = request.Request(url,
+                              data=json.dumps(data).encode("utf-8"),
+                              headers=headers)
         with request.urlopen(req, timeout=timeout) as response:
             return type("", (), {"content": response.read(), "ok": response.code < 400})()
 
@@ -190,7 +192,7 @@ class PresenceDetector(Thread):
         """ Should this Thread be stopped? """
         return self._killed
 
-    def stop(self, _signum: int = None, _frame: int = None):
+    def stop(self, _signum: int | None = None, _frame: int | None = None):
         """ Stop this thread as soon as possible """
         self._logger.log("Stopping...")
         self.stop_watchers()

--- a/presence-detector.py
+++ b/presence-detector.py
@@ -70,12 +70,16 @@ class PresenceDetector(Thread):
         self._killed = False
 
     @staticmethod
-    def _post(url: str, data: dict = {}, headers: dict = {}, timeout: int = None):
+    def _post(url: str, data: dict = None, headers: dict = None, timeout: int = None):
+        if data is None:
+            data = {}
+        if headers is None:
+            headers = {}
         data = json.dumps(data).encode("utf-8")
         req = request.Request(url, data=data, headers=headers)
-        response = request.urlopen(req, timeout=timeout)
-        return type("", (), {"content": response.read(), "ok": response.code < 400})()
-        
+        with request.urlopen(req, timeout=timeout) as response:
+            return type("", (), {"content": response.read(), "ok": response.code < 400})()
+
     def _ha_seen(self, client: str, seen: bool = True) -> bool:
         """ Call the HA device tracker 'see' service to update home/away status  """
         if seen:
@@ -186,7 +190,7 @@ class PresenceDetector(Thread):
         """ Should this Thread be stopped? """
         return self._killed
 
-    def stop(self, signum: int = None, frame: int = None):
+    def stop(self, _signum: int = None, _frame: int = None):
         """ Stop this thread as soon as possible """
         self._logger.log("Stopping...")
         self.stop_watchers()

--- a/presence-detector.py
+++ b/presence-detector.py
@@ -274,7 +274,7 @@ def main():
         "-c",
         "--config",
         help="Filename of configuration file",
-        default="/etc/config/settings.json",
+        default="/etc/config/presence-detector.settings.json",
     )
     args = parser.parse_args()
 

--- a/presence-detector.py
+++ b/presence-detector.py
@@ -179,7 +179,7 @@ class PresenceDetector(Thread):
         """ Should this Thread be stopped? """
         return self._killed
 
-    def stop(self):
+    def stop(self, signum: int = None, frame: int = None):
         """ Stop this thread as soon as possible """
         self._logger.log("Stopping...")
         self.stop_watchers()

--- a/presence-detector.py
+++ b/presence-detector.py
@@ -15,7 +15,7 @@ from threading import Thread
 from typing import Dict, Any, List, Callable
 
 from urllib import request
-
+from urllib.error import URLError, HTTPError
 
 class Logger:
     """ Class to handle logging to syslog """
@@ -70,9 +70,9 @@ class PresenceDetector(Thread):
         self._killed = False
 
     @staticmethod
-    def post(url: str, json: dict = {}, headers: dict = {}, timeout: int = None):
-        json = globals()["json"].dumps(json).encode("utf-8")
-        req = request.Request(url, data=json, headers=headers)
+    def _post(url: str, data: dict = {}, headers: dict = {}, timeout: int = None):
+        data = json.dumps(data).encode("utf-8")
+        req = request.Request(url, data=data, headers=headers)
         response = request.urlopen(req, timeout=timeout)
         return type("", (), {"content": response.read(), "ok": response.code < 400})()
         
@@ -88,14 +88,14 @@ class PresenceDetector(Thread):
             body.update(self._settings.params[client])
 
         try:
-            response = self.post(
+            response = self._post(
                 f"{self._settings.hass_url}/api/services/device_tracker/see",
-                json=body,
+                data=body,
                 headers={"Authorization": f"Bearer {self._settings.hass_token}"},
                 timeout=5,
             )
             self._logger.log(f"API Response: {response.content!r}", is_debug=True)
-        except Exception as ex:
+        except (URLError, HTTPError) as ex:
             self._logger.log(str(ex), is_debug=True)
             # Force full sync when HA returns
             self._full_sync_counter = 0


### PR DESCRIPTION
- [bugfix] Added additonal parameters to PresenceDetector.stop method to be graceful executed by signal.signal
- settings.json filename changed to presence-detector.settings.json (name too generic to be on /etc/config)
- Replaced requests library with urllib.request to lower the dependency footprint