### PR TITLE
fix: prefix clients with ap_name in ubus events

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The settings file looks like this:
       "dev_id": "phonedave"
     }
   },
-  "offline_after": 3,
+  "offline_after": 1,
   "poll_interval": 15,
   "full_sync_polls": 10,
   "ap_name": "",
@@ -50,7 +50,7 @@ Some settings will need a bit of explaining:
 * interfaces: This is an array of Wifi interface names to poll, prefixed with 'hostapd.' (it's the ubus service name).
 * do_not_track: This is an array of devices to ignore.
 * params: A dictionary containing additional parameters for specific devices. Those are sent together with MAC address and location name. Note here you could also override MAC and location name. For information on which keys you can add, see [here](https://www.home-assistant.io/integrations/device_tracker/#device_trackersee-service).
-* offline_after: Set a device as not_home after is has been absent for this many poll intervals. Set this to 1 to immediately notify HA when a device leaves the network. Default: 3
+* offline_after: Set a device as not_home after it has been absent for this many poll intervals. Set this to 1 to immediately notify HA when a device leaves the network. Set this to 1 to use the ubus leave event and immediately mark a device as away. Default: 1
 * poll_interval: Poll interval in seconds. Default: 15
 * full_sync_polls: Re-sync the device state of all devices every X poll intervals. This is to ensure device state is in sync,
   even after HA restarts, connectivity loss, or missed events. Default: 10

--- a/presence-detector.py
+++ b/presence-detector.py
@@ -287,9 +287,9 @@ class UbusWatcher(Thread):
                     # Ignore incomplete / invalid json
                     pass
                 if "assoc" in event:
-                    self._on_join(event['assoc']['address'])
+                    self._on_join(event["assoc"]["address"])
                 elif "disassoc" in event:
-                    self._on_leave(event['disassoc']['address'])
+                    self._on_leave(event["disassoc"]["address"])
             ubus.terminate()
             ubus.wait()
 

--- a/presence-detector.py
+++ b/presence-detector.py
@@ -46,7 +46,7 @@ class Settings:
             "interfaces": ["hostapd.wlan0"],
             "do_not_track": [],
             "params": {},
-            "offline_after": 3,
+            "offline_after": 1,
             "poll_interval": 15,
             "full_sync_polls": 10,
             "location": "home",
@@ -174,16 +174,24 @@ class PresenceDetector(Thread):
                 clients.extend(response["clients"].keys())
         return clients
 
+    def _on_join(self, client: str):
+        """Callback for the Ubus watcher thread when a client joins"""
+        if self._settings.ap_name:
+            client = f"{self._settings.ap_name}_{client}"
+        self.set_client_home(client)
+
     def _on_leave(self, client: str):
         """Callback for the Ubus watcher thread when a client leaves"""
         if self._settings.offline_after <= 1:
+            if self._settings.ap_name:
+                client = f"{self._settings.ap_name}_{client}"
             self.set_client_away(client)
 
     def start_watchers(self):
         """Start ubus watcher threads for every interface"""
         for interface in self._settings.interfaces:
             # Start an ubus watcher for every interface
-            watcher = UbusWatcher(interface, self.set_client_home, self._on_leave)
+            watcher = UbusWatcher(interface, self._on_join, self._on_leave)
             watcher.start()
             self._watchers.append(watcher)
 
@@ -217,15 +225,16 @@ class PresenceDetector(Thread):
             for client in seen_now:
                 self.set_client_home(client)
 
-            # Mark unseen clients as away after 'offline_after' intervals
-            for client in self._clients_seen.copy():
-                if client in seen_now:
-                    continue
-                self._clients_seen[client] -= 1
-                if self._clients_seen[client] > 0:
-                    continue
-                # Client has not been seen x times, mark as away
-                self.set_client_away(client)
+            # Mark unseen clients as away after 'offline_after' intervals if polling is enabled
+            if self._settings.offline_after > 1:
+                for client in self._clients_seen.copy():
+                    if client in seen_now:
+                        continue
+                    self._clients_seen[client] -= 1
+                    if self._clients_seen[client] > 0:
+                        continue
+                    # Client has not been seen x times, mark as away
+                    self.set_client_away(client)
 
             time.sleep(self._settings.poll_interval)
 
@@ -278,9 +287,9 @@ class UbusWatcher(Thread):
                     # Ignore incomplete / invalid json
                     pass
                 if "assoc" in event:
-                    self._on_join(event["assoc"]["address"])
+                    self._on_join(event['assoc']['address'])
                 elif "disassoc" in event:
-                    self._on_leave(event["disassoc"]["address"])
+                    self._on_leave(event['disassoc']['address'])
             ubus.terminate()
             ubus.wait()
 


### PR DESCRIPTION
fix: disable polling based away notification when offline_after <= 1
chore: set offline_after default to 1
docs: update README, clarify offline_after setting