### PR TITLE
paho mqtt v1 support for broker disconnect callback

### DIFF
--- a/presence-detector.py
+++ b/presence-detector.py
@@ -140,6 +140,7 @@ class PresenceDetector(Thread):
         else:
             # Version 1 is deprecated but still supported
             self._mqtt = mqtt.Client()
+            self._mqtt.on_disconnect = self._on_mqtt_disconnect_v1
         self._mqtt.username_pw_set(
             self._settings.mqtt_username, self._settings.mqtt_password
         )
@@ -155,6 +156,13 @@ class PresenceDetector(Thread):
 
     def _on_mqtt_disconnect(
         self, _client, _userdata, _disconnect_flags, reason_code, _properties
+    ):
+        """Callback for MQTT disconnections"""
+        self._logger.log(f"MQTT broker disconnected (rc: {reason_code})")
+        self._registered_clients.clear()
+
+    def _on_mqtt_disconnect_v1(
+        self, _client, _userdata, reason_code, _properties=None
     ):
         """Callback for MQTT disconnections"""
         self._logger.log(f"MQTT broker disconnected (rc: {reason_code})")


### PR DESCRIPTION
See https://github.com/rmoesbergen/openwrt-ha-device-tracker/issues/71#issuecomment-5301820321 for context.

The changes are not polished, I went for a proof of concept. So decide whether you want to incorporate them as is, improve them or disregard if they are not up to par.